### PR TITLE
Move AsyncTaskResult to com.amaze.filemanager.asynchronous.asynctasks package

### DIFF
--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/AsyncTaskResult.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/AsyncTaskResult.java
@@ -20,7 +20,7 @@
  */
 
 
-package com.amaze.filemanager.asynchronous.asynctasks.ssh;
+package com.amaze.filemanager.asynchronous.asynctasks;
 
 /**
  * Container for AsyncTask results. Allow either result object or exception to be contained.

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/GetSshHostFingerprintTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/GetSshHostFingerprintTask.java
@@ -28,6 +28,7 @@ import android.support.annotation.NonNull;
 import android.widget.Toast;
 
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
 import com.amaze.filemanager.filesystem.ssh.CustomSshJConfig;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
 import com.amaze.filemanager.utils.application.AppConfig;

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/PemToKeyPairTask.java
@@ -31,6 +31,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
 import com.amaze.filemanager.utils.application.AppConfig;
 import com.hierynomus.sshj.userauth.keyprovider.OpenSSHKeyV1KeyFile;
 

--- a/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
+++ b/app/src/main/java/com/amaze/filemanager/asynchronous/asynctasks/ssh/SshAuthenticationTask.java
@@ -29,6 +29,7 @@ import android.support.annotation.NonNull;
 import android.widget.Toast;
 
 import com.amaze.filemanager.R;
+import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
 import com.amaze.filemanager.filesystem.ssh.CustomSshJConfig;
 import com.amaze.filemanager.utils.application.AppConfig;
 

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -27,7 +27,7 @@ import android.util.Log;
 
 import com.amaze.filemanager.activities.MainActivity;
 import com.amaze.filemanager.database.UtilsHandler;
-import com.amaze.filemanager.asynchronous.asynctasks.ssh.AsyncTaskResult;
+import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
 import com.amaze.filemanager.asynchronous.asynctasks.ssh.PemToKeyPairTask;
 import com.amaze.filemanager.asynchronous.asynctasks.ssh.SshAuthenticationTask;
 import com.amaze.filemanager.utils.application.AppConfig;

--- a/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
+++ b/app/src/main/java/com/amaze/filemanager/ui/dialogs/SftpConnectDialog.java
@@ -46,7 +46,7 @@ import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.fragments.MainFragment;
 import com.amaze.filemanager.filesystem.ssh.SshClientUtils;
 import com.amaze.filemanager.filesystem.ssh.SshConnectionPool;
-import com.amaze.filemanager.asynchronous.asynctasks.ssh.AsyncTaskResult;
+import com.amaze.filemanager.asynchronous.asynctasks.AsyncTaskResult;
 import com.amaze.filemanager.asynchronous.asynctasks.ssh.PemToKeyPairTask;
 import com.amaze.filemanager.asynchronous.asynctasks.ssh.SshAuthenticationTask;
 import com.amaze.filemanager.asynchronous.asynctasks.ssh.GetSshHostFingerprintTask;


### PR DESCRIPTION
As you're moving the SSH related asynctasks, I'd also want to move `AsyncTaskResult` up to `com.amaze.filemanager.asynchronous.asynctasks` so it looks more general purpose for use elsewhere - more specifically, my base work for TeamAmaze/AmazeFileManager#138 will need this change.