### PR TITLE
Add BouncyCastle classes and BC/SC RSA providers to proguard config

### DIFF
--- a/app/proguard.cfg
+++ b/app/proguard.cfg
@@ -90,6 +90,7 @@
 -keep class org.spongycastle.jcajce.provider.asymmetric.util.* {*;}
 -keep class org.spongycastle.jcajce.provider.asymmetric.dh.* {*;}
 -keep class org.spongycastle.jcajce.provider.asymmetric.ec.* {*;}
+-keep class org.spongycastle.jcajce.provider.asymmetric.rsa.* {*;}
 
 -keep class org.spongycastle.jcajce.provider.digest.** {*;}
 -keep class org.spongycastle.jcajce.provider.keystore.** {*;}
@@ -97,6 +98,31 @@
 -keep class org.spongycastle.jcajce.spec.* {*;}
 -keep class org.spongycastle.jce.** {*;}
 
+#From here BouncyCastle
+-keep class org.bouncycastle.crypto.* {*;}
+-keep class org.bouncycastle.crypto.agreement.** {*;}
+-keep class org.bouncycastle.crypto.digests.* {*;}
+-keep class org.bouncycastle.crypto.ec.* {*;}
+-keep class org.bouncycastle.crypto.encodings.* {*;}
+-keep class org.bouncycastle.crypto.engines.* {*;}
+-keep class org.bouncycastle.crypto.macs.* {*;}
+-keep class org.bouncycastle.crypto.modes.* {*;}
+-keep class org.bouncycastle.crypto.paddings.* {*;}
+-keep class org.bouncycastle.crypto.params.* {*;}
+-keep class org.bouncycastle.crypto.prng.* {*;}
+-keep class org.bouncycastle.crypto.signers.* {*;}
+
+-keep class org.bouncycastle.jcajce.provider.asymmetric.* {*;}
+-keep class org.bouncycastle.jcajce.provider.asymmetric.util.* {*;}
+-keep class org.bouncycastle.jcajce.provider.asymmetric.dh.* {*;}
+-keep class org.bouncycastle.jcajce.provider.asymmetric.ec.* {*;}
+-keep class org.bouncycastle.jcajce.provider.asymmetric.rsa.* {*;}
+
+-keep class org.bouncycastle.jcajce.provider.digest.** {*;}
+-keep class org.bouncycastle.jcajce.provider.keystore.** {*;}
+-keep class org.bouncycastle.jcajce.provider.symmetric.** {*;}
+-keep class org.bouncycastle.jcajce.spec.* {*;}
+-keep class org.bouncycastle.jce.** {*;}
 
 -dontwarn javax.naming.**
 


### PR DESCRIPTION
For sshj to function properly.

Once sshj gets a new release in public repos we may try removing BouncyCastle altogether.