### PR TITLE
Fix for UtilHandler refactoring on SCP/SFTP targets

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,8 +80,10 @@ dependencies {
 
     //For tests
     androidTestImplementation 'junit:junit:4.12'//tests the app logic
-    testImplementation "org.robolectric:robolectric:3.6.1"//tests android interaction
-    testImplementation "org.robolectric:shadows-multidex:3.6.1"//tests android interaction
+    testImplementation "org.robolectric:robolectric:3.7"//tests android interaction
+    testImplementation "org.robolectric:shadows-multidex:3.7"//tests android interaction
+
+    testImplementation "org.apache.sshd:sshd-core:1.7.0"
 
     //Detect memory leaks
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.5.3'
@@ -111,7 +113,7 @@ dependencies {
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
-    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.21'
+    implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.25'
 
     //implementation files('libs/ftplet-api-1.1.0-SNAPSHOT.jar')
     // https://mvnrepository.com/artifact/org.apache.ftpserver/ftplet-api

--- a/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
+++ b/app/src/main/java/com/amaze/filemanager/database/models/OperationData.java
@@ -1,5 +1,7 @@
 package com.amaze.filemanager.database.models;
 
+import android.text.TextUtils;
+
 import com.amaze.filemanager.database.UtilsHandler;
 import com.amaze.filemanager.database.UtilsHandler.Operation;
 
@@ -69,4 +71,17 @@ public class OperationData {
         this.sshKey = sshKey;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("OperationData type=[").append(type).append("],path=[")
+                .append(path).append("]");
+
+        if(!TextUtils.isEmpty(hostKey))
+            sb.append(",hostKey=[").append(hostKey).append(']');
+
+        if(!TextUtils.isEmpty(sshKeyName))
+            sb.append(",sshKeyName=[").append(sshKeyName).append("],sshKey=[redacted]");
+
+        return sb.toString();
+    }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshClientUtils.java
@@ -46,6 +46,7 @@ import net.schmizz.sshj.sftp.SFTPClient;
 import java.io.File;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
+import java.security.KeyPair;
 import java.util.List;
 
 import static com.amaze.filemanager.filesystem.ssh.SshConnectionPool.SSH_URI_PREFIX;
@@ -262,5 +263,13 @@ public abstract class SshClientUtils
                 e.printStackTrace();
             }
         }).start();
+    }
+
+    //Decide the SSH URL depends on password/selected KeyPair
+    public static String deriveSftpPathFrom(String hostname, int port, String username, String password,
+                                      KeyPair selectedParsedKeyPair) {
+        return (selectedParsedKeyPair != null || password == null) ?
+                String.format("ssh://%s@%s:%d", username, hostname, port) :
+                String.format("ssh://%s:%s@%s:%d", username, password, hostname, port);
     }
 }

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -23,6 +23,7 @@ package com.amaze.filemanager.filesystem.ssh;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.amaze.filemanager.activities.MainActivity;
@@ -89,7 +90,7 @@ public class SshConnectionPool
      * @return {@link SSHClient} connection, already opened and authenticated
      * @throws IOException IOExceptions that occur during connection setup
      */
-    public SSHClient getConnection(@NonNull String url) throws IOException {
+    public SSHClient getConnection(@NonNull String url)  {
         url = SshClientUtils.extractBaseUriFrom(url);
 
         SSHClient client = connections.get(url);
@@ -103,6 +104,47 @@ public class SshConnectionPool
                 expire(client);
                 connections.remove(url);
                 client = create(url);
+                if(client != null)
+                    connections.put(url, client);
+            }
+        }
+        return client;
+    }
+
+    /**
+     * Obtain a {@link SSHClient} connection from the underlying connection pool.
+     *
+     * Beneath it will return the connection if it exists; otherwise it will create a new one and
+     * put it into the connection pool.
+     *
+     * Different from {@link #getConnection(String)} above, this accepts broken down parameters as
+     * convenience method during setting up SCP/SFTP connection.
+     *
+     * @param host host name/IP, required
+     * @param port SSH server port, required
+     * @param hostFingerprint expected host fingerprint, required
+     * @param username username, required
+     * @param password password, required if using password to authenticate
+     * @param keyPair {@link KeyPair}, required if using key-based authentication
+     * @return {@link SSHClient} connection
+     */
+    public SSHClient getConnection(@NonNull String host, int port, @NonNull String hostFingerprint,
+                                   @NonNull String username, @Nullable String password,
+                                   @Nullable KeyPair keyPair) {
+
+        String url = SshClientUtils.deriveSftpPathFrom(host, port, username, password, keyPair);
+
+        SSHClient client = connections.get(url);
+        if(client == null) {
+            client = create(host, port, hostFingerprint, username, password, keyPair);
+            if(client != null)
+                connections.put(url, client);
+        } else {
+            if(!validate(client)) {
+                Log.d(TAG, "Connection no longer usable. Reconnecting...");
+                expire(client);
+                connections.remove(url);
+                client = create(host, port, hostFingerprint, username, password, keyPair);
                 if(client != null)
                     connections.put(url, client);
             }
@@ -127,7 +169,7 @@ public class SshConnectionPool
         });
     }
 
-    private SSHClient create(@NonNull String url) throws IOException {
+    private SSHClient create(@NonNull String url) {
         return create(Uri.parse(url));
     }
 
@@ -145,22 +187,35 @@ public class SshConnectionPool
             port = SSH_DEFAULT_PORT;
 
         UtilsHandler utilsHandler = AppConfig.getInstance().getUtilsHandler();
-        try {
-            String pem = utilsHandler.getSshAuthPrivateKey(uri.toString());
-            AtomicReference<KeyPair> keyPair = new AtomicReference<>(null);
-            if(pem != null && !"".equals(pem)) {
+        String pem = utilsHandler.getSshAuthPrivateKey(uri.toString());
+
+        AtomicReference<KeyPair> keyPair = new AtomicReference<>(null);;
+        if(pem != null && !"".equals(pem)) {
+            try {
                 CountDownLatch latch = new CountDownLatch(1);
                 new PemToKeyPairTask(pem, result -> {
-                    if(result.result != null){
+                    if (result.result != null) {
                         keyPair.set(result.result);
                         latch.countDown();
                     }
                 }).execute();
                 latch.await();
+            } catch(InterruptedException e) {
+                throw new RuntimeException(e);
             }
+        }
+
+        return create(host, port, utilsHandler.getSshHostKey(uri.toString()), username, password,
+                keyPair.get());
+    }
+
+    private SSHClient create(@NonNull String host, int port, @NonNull String hostKey,
+                             @NonNull String username, @Nullable String password,
+                             @Nullable KeyPair keyPair) {
+
+        try {
             AsyncTaskResult<SSHClient> taskResult = new SshAuthenticationTask(host, port,
-                    utilsHandler.getSshHostKey(uri.toString()),
-                    username, password, keyPair.get()).execute().get();
+                    hostKey, username, password, keyPair).execute().get();
 
             SSHClient client = taskResult.result;
             return client;

--- a/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
+++ b/app/src/main/java/com/amaze/filemanager/filesystem/ssh/SshConnectionPool.java
@@ -190,7 +190,7 @@ public class SshConnectionPool
         String pem = utilsHandler.getSshAuthPrivateKey(uri.toString());
 
         AtomicReference<KeyPair> keyPair = new AtomicReference<>(null);;
-        if(pem != null && !"".equals(pem)) {
+        if(pem != null && !pem.isEmpty()) {
             try {
                 CountDownLatch latch = new CountDownLatch(1);
                 new PemToKeyPairTask(pem, result -> {

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/CreateFileOnSshdTest.java
@@ -1,0 +1,77 @@
+package com.amaze.filemanager.filesystem.ssh;
+
+import android.os.Environment;
+
+import com.amaze.filemanager.BuildConfig;
+import com.amaze.filemanager.filesystem.ssh.test.BlockFileCreationFileSystemProvider;
+import com.amaze.filemanager.filesystem.ssh.test.TestHostKeyProvider;
+
+import org.apache.sshd.common.file.FileSystemFactory;
+import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
+import org.apache.sshd.common.session.Session;
+import org.apache.sshd.server.SshServer;
+import org.apache.sshd.server.auth.pubkey.AcceptAllPublickeyAuthenticator;
+import org.apache.sshd.server.scp.ScpCommandFactory;
+import org.apache.sshd.server.subsystem.sftp.SftpSubsystemFactory;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.multidex.ShadowMultiDex;
+
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(constants = BuildConfig.class, shadows = {ShadowMultiDex.class})
+public class CreateFileOnSshdTest {
+
+    private SshServer server;
+
+    private static TestHostKeyProvider hostKeyProvider;
+
+    @BeforeClass
+    public static void bootstrap() throws Exception {
+        hostKeyProvider = new TestHostKeyProvider();
+    }
+
+    @After
+    public void tearDown(){
+        if(server != null && server.isOpen())
+            server.close(true);
+    }
+
+    @Test
+    public void testCreateFileNormal() throws Exception {
+        createSshServer(new VirtualFileSystemFactory(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath())));
+    }
+
+    @Test
+    public void testCreateFilePermissionDenied() throws Exception{
+        createSshServer(new VirtualFileSystemFactory(){
+            @Override
+            public FileSystem createFileSystem(Session session) throws IOException {
+                return new BlockFileCreationFileSystemProvider().newFileSystem(Paths.get(Environment.getExternalStorageDirectory().getAbsolutePath()), Collections.emptyMap());
+            }
+        });
+    }
+
+    private void createSshServer(FileSystemFactory fileSystemFactory) throws Exception {
+        server = SshServer.setUpDefaultServer();
+
+        server.setFileSystemFactory(fileSystemFactory);
+        server.setPublickeyAuthenticator(AcceptAllPublickeyAuthenticator.INSTANCE);
+        server.setPort(22222);
+        server.setHost("127.0.0.1");
+        server.setKeyPairProvider(hostKeyProvider);
+        server.setCommandFactory(new ScpCommandFactory());
+        server.setSubsystemFactories(Arrays.asList(new SftpSubsystemFactory()));
+        server.setPasswordAuthenticator(((username, password, session) -> username.equals("testuser") && password.equals("testpassword")));
+        server.start();
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/BlockFileCreationFileSystemProvider.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/BlockFileCreationFileSystemProvider.java
@@ -1,0 +1,39 @@
+package com.amaze.filemanager.filesystem.ssh.test;
+
+import org.apache.sshd.common.file.root.RootedFileSystem;
+import org.apache.sshd.common.file.root.RootedFileSystemProvider;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.nio.file.FileSystemException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Collections;
+import java.util.Set;
+
+public class BlockFileCreationFileSystemProvider extends RootedFileSystemProvider
+{
+    /**
+     * Read only.
+     * @param path
+     * @param options
+     * @param attrs
+     * @return
+     * @throws IOException
+     */
+    @Override
+    public FileChannel newFileChannel(Path path, Set<? extends OpenOption> options, FileAttribute<?>... attrs) throws IOException {
+        Path r = unroot(path);
+        FileSystemProvider p = provider(r);
+        return p.newFileChannel(r, Collections.singleton(StandardOpenOption.READ), attrs);
+    }
+
+    @Override
+    public OutputStream newOutputStream(Path path, OpenOption... options) throws IOException {
+        throw new FileSystemException("Unsupported operation");
+    }
+}

--- a/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestHostKeyProvider.java
+++ b/app/src/test/java/com/amaze/filemanager/filesystem/ssh/test/TestHostKeyProvider.java
@@ -1,0 +1,28 @@
+package com.amaze.filemanager.filesystem.ssh.test;
+
+import org.apache.sshd.common.keyprovider.KeyPairProvider;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.util.Collections;
+
+public class TestHostKeyProvider implements KeyPairProvider {
+
+    private KeyPair keyPair;
+
+    public TestHostKeyProvider() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA", "BC");
+        keyPairGenerator.initialize(1024, new SecureRandom());
+        keyPair = keyPairGenerator.generateKeyPair();
+    }
+
+    @Override
+    public Iterable<KeyPair> loadKeys() {
+        return Collections.singleton(keyPair);
+    }
+
+    public KeyPair getKeyPair() {
+        return keyPair;
+    }
+}

--- a/app/src/test/resources/simplelogger.properties
+++ b/app/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=debug


### PR DESCRIPTION
Not a very pretty fix... but seems adding another path for getting SSH connections without via database query is the only way to go (for the time being).

Also added support for writing test cases against SSH-related components (though not fully utilised yet).