### PR TITLE
Put version variable to separate ext section instead of inline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,10 @@ android {
     }
 }
 
+ext {
+    robolectricVersion = '3.8'
+}
+
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.readystatesoftware.systembartint:systembartint:1.0.3'
@@ -82,7 +86,6 @@ dependencies {
     //For tests
     androidTestImplementation 'junit:junit:4.12'//tests the app logic
 
-    def robolectricVersion = '3.8'
     testImplementation "org.robolectric:robolectric:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-multidex:$robolectricVersion"//tests android interaction
     testImplementation "org.robolectric:shadows-httpclient:$robolectricVersion"//tests android interaction


### PR DESCRIPTION
Reference: https://medium.com/@ivan_m/use-variables-to-manage-gradle-android-dependencies-library-version-numbers-92f0e362a2fc