### PR TITLE
Tweaks to prevent name clashes between debug and release builds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,12 +49,12 @@
         android:banner="@drawable/about_header">
 
         <activity
-            android:label="Amaze"
+            android:label="@string/appbar_name"
             android:launchMode="singleInstance"
             android:name=".activities.MainActivity"
             android:theme="@style/appCompatLight">
 
-            <intent-filter>
+            <intent-filter android:label="@string/appbar_name">
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
@@ -212,7 +212,7 @@
         </receiver>
         
         <provider
-            android:authorities="com.amaze.filemanager.FILE_PROVIDER"
+            android:authorities="${applicationId}.FILE_PROVIDER"
             android:name=".utils.GenericFileProvider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/app/src/main/java/com/amaze/filemanager/utils/GenericFileProvider.java
+++ b/app/src/main/java/com/amaze/filemanager/utils/GenericFileProvider.java
@@ -2,6 +2,8 @@ package com.amaze.filemanager.utils;
 
 import android.support.v4.content.FileProvider;
 
+import com.amaze.filemanager.BuildConfig;
+
 /**
  * Created by Vishal on 20-08-2017.
  *
@@ -10,6 +12,6 @@ import android.support.v4.content.FileProvider;
 
 public class GenericFileProvider extends FileProvider {
 
-    public static final String PROVIDER_NAME = "com.amaze.filemanager.FILE_PROVIDER";
+    public static final String PROVIDER_NAME = BuildConfig.APPLICATION_ID + ".FILE_PROVIDER";
 
 }


### PR DESCRIPTION
* Changed app icon name in launcher view same as appbar name
* Change FILE_PROVIDER prefix same as application ID

SO Reference:
* [Using build types in Gradle to run same app that uses ContentProvider on one device](https://stackoverflow.com/questions/16777534/using-build-types-in-gradle-to-run-same-app-that-uses-contentprovider-on-one-dev)
* [How to change an Android app's name?](https://stackoverflow.com/questions/5443304/how-to-change-an-android-apps-name)